### PR TITLE
fix: adjust for lucidworks change to template val

### DIFF
--- a/client/assets/components/documentList/documentList.html
+++ b/client/assets/components/documentList/documentList.html
@@ -2,6 +2,7 @@
   <div ng-repeat="doc in vm.docs" ng-switch="::vm.getDocType(doc)">
     <!-- <document-example ng-switch-when="string_matching_data_connector" doc="doc" highlight="vm.highlighting"></document-example> -->
     <document-file ng-switch-when="lucid.anda/file" doc="doc" position="vm.getDocPosition(doc,vm.docs)" highlight="vm.highlighting"></document-file>
+    <document-file ng-switch-when="lucid.smb/smb" doc="doc" position="vm.getDocPosition(doc,vm.docs)" highlight="vm.highlighting"></document-file>
     <document-jira ng-switch-when="lucid.anda/jira" doc="doc" position="vm.getDocPosition(doc,vm.docs)" highlight="vm.highlighting"></document-jira>
     <document-slack ng-switch-when="lucid.slack/slack" doc="doc" position="vm.getDocPosition(doc,vm.docs)" highlight="vm.highlighting"></document-slack>
     <document-twitter ng-switch-when="lucid.twitter.search/twitter_search" doc="doc" position="vm.getDocPosition(doc,vm.docs)" highlight="vm.highlighting"></document-twitter>


### PR DESCRIPTION
Apparently lucidworks changed the value stored for
_lw_data_source_type_s during indexing which caused cocosearch to
display data using the wrong template.

fixes #1